### PR TITLE
Fix vendor ID resolution and add slides

### DIFF
--- a/docs/model_registry_story.md
+++ b/docs/model_registry_story.md
@@ -1,0 +1,35 @@
+# Story Behind the Model Registry Changes
+
+## Introduction
+In the latest update we reworked how the application handles its AI model registry. Previously the registry used a single flat dictionary where each key was a model name. This caused duplicate keys when a model was offered by multiple vendors. Only the last model inserted remained in the registry, so information for other vendors disappeared silently.
+
+### For Kids
+Imagine you have a toy box where you put your toys. If you put two toys with the same name in the box, only the last one stays because the old one gets pushed out without you noticing. We fixed the box so it keeps all the toys by storing them in little sections labeled by who gave them to you.
+
+### For High School Students
+Think of the registry as a map between names of AI models and the details about them. If a model can be supplied by AWS or Anthropic, and we stored them by the same key, the second one overwritten the first. We solved this by mapping each model name to a dictionary of vendors. Now we keep both versions and pick the right one when asked.
+
+### For an Academic Audience
+The new design introduces `_models_by_vendor: Dict[str, Dict[Vendor, AIModel]]`. It maps canonical model names to nested dictionaries keyed by vendor. The earlier implementation used a single `Dict[str, AIModel]` which led to key collisions because vendor variants share canonical names. The new structure prevents silent overwrites while still offering backward compatibility through `available_models`, a view choosing Anthropic versions by default. This pattern parallels a two-layer cache where the first layer groups by canonical name and the second resolves the vendor instance.
+
+---
+
+## Architectural Patterns
+1. **Registry Pattern** – The application maintains a central collection of model definitions that can be looked up by name. By grouping entries by vendor we avoid collisions. This pattern makes adding new vendors straightforward.
+2. **Factory Methods** – The `AIModel` class exposes `claude_3_haiku()` as a factory method, ensuring consistent creation and encapsulating defaults.
+3. **Backward Compatibility Layer** – `available_models` exposes a flattened view of the registry so existing callers do not break. It acts like the Façade pattern, hiding the new complexity behind a simpler interface.
+
+## Why We Did It
+- **Bug Fix** – Duplicate keys meant one vendor’s configuration disappeared when the application started. This could send requests to the wrong vendor or lose vendor-specific pricing.
+- **Extension** – By storing per-vendor data explicitly, we can add additional vendors without rewriting call sites. Tests now verify retrieving vendor-specific models.
+
+## Real Life Analogy
+Think of a library with many copies of the same book but from different publishers. The previous system put them all on one shelf labeled with the book title. New arrivals replaced old ones. The new system first groups books by title, then stores copies from each publisher separately. When someone asks for a book, we can hand them the publisher they want.
+
+## Socratic Tutor Questions
+1. Why might silently overwriting keys be dangerous?
+2. How does grouping models by vendor help prevent mistakes?
+3. What advantages come from keeping a backward compatible `available_models` dictionary?
+
+Consider how this approach scales if we add more vendors. Would any part of the design need revisiting?
+

--- a/docs/practice_questions.md
+++ b/docs/practice_questions.md
@@ -1,0 +1,57 @@
+# Practice Questions and Key Concepts
+
+Below are practice questions to solidify your understanding, followed by tables of key terms and fundamental propositions about architecture and the model registry.
+
+## Practice Questions
+1. What problem did the original flat model registry cause when multiple vendors provided the same model?
+2. How does the new `_models_by_vendor` structure solve this issue?
+3. Why do we keep the `available_models` dictionary, and what vendor does it prefer by default?
+4. Imagine adding a new vendor tomorrow. What part of the design makes this simpler?
+5. When might you still use `get_model()` without specifying a vendor?
+6. Give a real life analogy that explains why storing vendor information separately helps.
+7. What is a factory method in `AIModel` and why might we use it?
+8. How does the registry pattern relate to a phone book or a library catalog?
+9. Explain how the Façade pattern shows up in this code change.
+10. What happens if you request a model that is not available for a specified vendor?
+
+## Everyday Analogy
+Think of a grocery store where the same fruit can come from different farms. If you only label bins by fruit type, you might lose track of which farm each piece came from. By having sub-bins for each farm, you can select oranges from Farm A or Farm B depending on your preference.
+
+## Key Terms
+| Category | Term | Proposition |
+|----------|------|------------|
+|Registry|Model Registry|"A registry is a type of catalog used to store and look up models"|
+|Registry|Canonical Name|"A canonical name is a unique identifier for a model"|
+|Registry|Vendor|"A vendor is a provider of a model"|
+|Factory|Factory Method|"A factory method is a type of constructor for creating objects"|
+|Factory|AIModel.claude_3_haiku|"`claude_3_haiku` is a factory method that returns an AIModel"|
+|Compatibility|Backward Compatibility|"Backward compatibility is caused by the need to support older code"|
+|Compatibility|Facade Pattern|"The facade pattern explains hiding complexity behind a simple interface"|
+|Cost|ModelCosts|"ModelCosts is a data class that stores pricing information"|
+|Cost|Cost Calculation|"Cost calculation is caused by multiplying token counts with token prices"|
+|Resolution|Model Mapping|"Model mapping is a type of lookup between canonical names and vendor IDs"|
+|Resolution|resolve_model_id|"`resolve_model_id` is a method that explains how to convert names to vendor-specific IDs"|
+|Resolution|get_vendor_model_id|"`get_vendor_model_id` is a method that retrieves vendor-specific IDs"|
+|Error Handling|ValueError|"ValueError is raised when invalid input causes an error"|
+|Error Handling|Invalid Vendor|"An invalid vendor is a cause for raising an exception"|
+|Testing|pytest|"pytest is a type of testing framework"|
+|Testing|Unit Test|"A unit test explains how a small piece of code behaves"|
+|Pattern|Registry Pattern|"Registry pattern is a type of design pattern"|
+|Pattern|Factory Pattern|"Factory pattern is caused by needing consistent object creation"|
+|Pattern|Mapping Table|"A mapping table explains associations between two domains"|
+|Pattern|Two-Layer Cache|"Two-layer cache is a type of nested lookup design"|
+
+## Fundamental Concepts
+| Category | Concept | Proposition |
+|----------|---------|-------------|
+|Design|Separation of Concerns|"Separation of concerns is a type of modular design"|
+|Design|Encapsulation|"Encapsulation explains hiding implementation details"|
+|Design|Abstraction|"Abstraction is caused by representing complex ideas with simpler ones"|
+|Data|Canonical Names|"Canonical names are a type of unique identifier"|
+|Data|Vendor Variants|"Vendor variants are caused by different providers offering the same model"|
+|Operations|Lookup|"Lookup explains retrieving a value from a registry"|
+|Operations|Validation|"Validation is a type of error checking"|
+|Operations|Mapping|"Mapping is caused by converting one identifier to another"|
+|Evolution|Backward Compatibility|"Backward compatibility is a type of design constraint for evolution"|
+|Evolution|Extensibility|"Extensibility explains how a system can grow with new vendors"|
+

--- a/docs/slides.md
+++ b/docs/slides.md
@@ -1,0 +1,36 @@
+# Story of the Registry Redesign
+
+---
+## Why change the registry?
+- Duplicate models from multiple vendors were overwriting each other
+- Needed a way to keep them all without breaking existing code
+
+---
+## The new structure
+```mermaid
+graph TD
+    A[Canonical Name] --> B{Vendor}
+    B -->|AWS| C[Model Variant]
+    B -->|Anthropic| D[Model Variant]
+```
+
+---
+## In simple terms
+- **Kid:** We put models in little boxes for each vendor so none get lost.
+- **High School:** A dictionary of dictionaries lets us track each vendor's version.
+- **Academic:** `_models_by_vendor` prevents key collisions while `available_models` maintains backward compatibility.
+
+---
+## Usage example
+```python
+models = SupportedModels()
+haiku = models.get_model("claude-3-haiku-20240307", Vendor.AWS)
+```
+
+---
+## Benefits
+- No silent overwrites
+- Easy vendor-specific lookups
+- Backwards compatible interface
+
+---

--- a/src/ai_dev_console/models/model.py
+++ b/src/ai_dev_console/models/model.py
@@ -125,97 +125,116 @@ class SupportedModels:
             "claude-3-7-sonnet-20250219",
         }
 
+        # Mapping of canonical model names to vendor specific versions.  Previous
+        # versions of this code attempted to initialise ``available_models`` with
+        # duplicate keys which resulted in the first definitions silently being
+        # overwritten.  The structure below keeps each canonical model only once
+        # and stores the vendor specific variants in a nested dictionary.
+        self._models_by_vendor: Dict[str, Dict[Vendor, AIModel]] = {
+            "claude-3-7-sonnet-20250219": {
+                Vendor.AWS: AIModel(
+                    name="claude-3-7-sonnet-20250219",
+                    vendor=Vendor.AWS,
+                    costs=ModelCosts(
+                        input_cost_per_million_tokens=Decimal("3.0"),
+                        output_cost_per_million_tokens=Decimal("15.0"),
+                    ),
+                    context_window=200000,
+                    max_output_tokens=64000,
+                    supports_vision=True,
+                    supports_message_batches=True,
+                    training_cutoff=datetime(2025, 2, 19),
+                    description="Our most expressive model",
+                    comparative_latency="Fastest",
+                ),
+                Vendor.ANTHROPIC: AIModel(
+                    name="claude-3-7-sonnet-20250219",
+                    vendor=Vendor.ANTHROPIC,
+                    costs=ModelCosts(
+                        input_cost_per_million_tokens=Decimal("4.0"),
+                        output_cost_per_million_tokens=Decimal("20.0"),
+                    ),
+                    context_window=200000,
+                    max_output_tokens=8192,
+                    supports_vision=True,
+                    supports_message_batches=True,
+                    training_cutoff=datetime(2025, 2, 19),
+                    description="Our most expressive model",
+                    comparative_latency="Fast",
+                ),
+            },
+            "claude-3-5-sonnet-20241022": {
+                Vendor.AWS: AIModel(
+                    name="claude-3-5-sonnet-20241022",
+                    vendor=Vendor.AWS,
+                    costs=ModelCosts(
+                        input_cost_per_million_tokens=Decimal("3.0"),
+                        output_cost_per_million_tokens=Decimal("15.0"),
+                    ),
+                    context_window=200000,
+                    max_output_tokens=8192,
+                    supports_vision=True,
+                    supports_message_batches=True,
+                    training_cutoff=datetime(2024, 4, 1),
+                    description="Our most intelligent model",
+                    comparative_latency="Fast",
+                ),
+                Vendor.ANTHROPIC: AIModel(
+                    name="claude-3-5-sonnet-20241022",
+                    vendor=Vendor.ANTHROPIC,
+                    costs=ModelCosts(
+                        input_cost_per_million_tokens=Decimal("3.0"),
+                        output_cost_per_million_tokens=Decimal("15.0"),
+                    ),
+                    context_window=200000,
+                    max_output_tokens=8192,
+                    supports_vision=True,
+                    supports_message_batches=True,
+                    training_cutoff=datetime(2024, 4, 1),
+                    description="Our most intelligent model",
+                    comparative_latency="Fast",
+                ),
+            },
+            "claude-3-haiku-20240307": {
+                Vendor.ANTHROPIC: AIModel(
+                    name="claude-3-haiku-20240307",
+                    vendor=Vendor.ANTHROPIC,
+                    costs=ModelCosts(
+                        input_cost_per_million_tokens=Decimal("1.0"),
+                        output_cost_per_million_tokens=Decimal("5.0"),
+                    ),
+                    context_window=200000,
+                    max_output_tokens=8192,
+                    supports_vision=False,
+                    supports_message_batches=True,
+                    training_cutoff=datetime(2024, 7, 1),
+                    description="Our fastest model",
+                    comparative_latency="Fastest",
+                ),
+                Vendor.AWS: AIModel(
+                    name="claude-3-haiku-20240307",
+                    vendor=Vendor.AWS,
+                    costs=ModelCosts(
+                        input_cost_per_million_tokens=Decimal("1.0"),
+                        output_cost_per_million_tokens=Decimal("5.0"),
+                    ),
+                    context_window=200000,
+                    max_output_tokens=8192,
+                    supports_vision=False,
+                    supports_message_batches=True,
+                    training_cutoff=datetime(2024, 7, 1),
+                    description="Our fastest model",
+                    comparative_latency="Fastest",
+                ),
+            },
+        }
+
+        # Maintain backwards compatibility: expose a flat dictionary of default
+        # models so existing code (and tests) that iterate over ``available_models``
+        # continues to work.  Anthropic versions are preferred when available.
         self.available_models: Dict[str, AIModel] = {
-            "claude-3-7-sonnet-20250219": AIModel(
-                name="claude-3-7-sonnet-20250219",
-                vendor=Vendor.AWS,
-                costs=ModelCosts(
-                    input_cost_per_million_tokens=Decimal("3.0"),
-                    output_cost_per_million_tokens=Decimal("15.0"),
-                ),
-                context_window=200000,
-                max_output_tokens=64000,
-                supports_vision=True,
-                supports_message_batches=True,
-                training_cutoff=datetime(2025, 2, 19),
-                description="Our most expressive model",
-                comparative_latency="Fastest",
-            ),
-            "claude-3-7-sonnet-20250219": AIModel(
-                name="claude-3-7-sonnet-20250219",
-                vendor=Vendor.ANTHROPIC,
-                costs=ModelCosts(
-                    input_cost_per_million_tokens=Decimal("4.0"),
-                    output_cost_per_million_tokens=Decimal("20.0"),
-                ),
-                context_window=200000,
-                max_output_tokens=8192,
-                supports_vision=True,
-                supports_message_batches=True,
-                training_cutoff=datetime(2025, 2, 19),
-                description="Our most expressive model",
-                comparative_latency="Fast",
-            ),
-            "claude-3-5-sonnet-20241022": AIModel(
-                name="claude-3-5-sonnet-20241022",
-                vendor=Vendor.AWS,
-                costs=ModelCosts(
-                    input_cost_per_million_tokens=Decimal("3.0"),
-                    output_cost_per_million_tokens=Decimal("15.0"),
-                ),
-                context_window=200000,
-                max_output_tokens=8192,
-                supports_vision=True,
-                supports_message_batches=True,
-                training_cutoff=datetime(2024, 4, 1),
-                description="Our most intelligent model",
-                comparative_latency="Fast",
-            ),
-            "claude-3-5-sonnet-20241022": AIModel(
-                name="claude-3-5-sonnet-20241022",
-                vendor=Vendor.ANTHROPIC,
-                costs=ModelCosts(
-                    input_cost_per_million_tokens=Decimal("3.0"),
-                    output_cost_per_million_tokens=Decimal("15.0"),
-                ),
-                context_window=200000,
-                max_output_tokens=8192,
-                supports_vision=True,
-                supports_message_batches=True,
-                training_cutoff=datetime(2024, 4, 1),
-                description="Our most intelligent model",
-                comparative_latency="Fast",
-            ),
-            "claude-3-haiku-20240307": AIModel(
-                name="claude-3-haiku-20240307",
-                vendor=Vendor.ANTHROPIC,
-                costs=ModelCosts(
-                    input_cost_per_million_tokens=Decimal("1.0"),
-                    output_cost_per_million_tokens=Decimal("5.0"),
-                ),
-                context_window=200000,
-                max_output_tokens=8192,
-                supports_vision=False,
-                supports_message_batches=True,
-                training_cutoff=datetime(2024, 7, 1),
-                description="Our fastest model",
-                comparative_latency="Fastest",
-            ),
-            "claude-3-haiku-20240307": AIModel(
-                name="claude-3-haiku-20240307",
-                vendor=Vendor.AWS,
-                costs=ModelCosts(
-                    input_cost_per_million_tokens=Decimal("1.0"),
-                    output_cost_per_million_tokens=Decimal("5.0"),
-                ),
-                context_window=200000,
-                max_output_tokens=8192,
-                supports_vision=False,
-                supports_message_batches=True,
-                training_cutoff=datetime(2024, 7, 1),
-                description="Our fastest model",
-                comparative_latency="Fastest",
-            ),
+            name: models.get(Vendor.ANTHROPIC, next(iter(models.values())))
+            for name, models in self._models_by_vendor.items()
         }
 
     # TODO: This should be part of the client adapter, not part of the model.
@@ -253,11 +272,23 @@ class SupportedModels:
         model_id = self.get_vendor_model_id(model_name, Vendor.AWS)
         return f"arn:aws:bedrock:{region}:{account_id}:inference-profile/{region_prefix}.{model_id}"
 
-    def get_model(self, model_name: str) -> AIModel:
-        """Get a model by name."""
-        if model_name not in self.available_models:
+    def get_model(self, model_name: str, vendor: Optional[Vendor] = None) -> AIModel:
+        """Get a model by name and optional vendor."""
+        if model_name not in self._models_by_vendor:
             raise ValueError(f"Model '{model_name}' not found")
-        return self.available_models[model_name]
+
+        models = self._models_by_vendor[model_name]
+
+        if vendor is None:
+            # Default to the Anthropic version when available
+            return models.get(Vendor.ANTHROPIC, next(iter(models.values())))
+
+        if vendor not in models:
+            raise ValueError(
+                f"Model '{model_name}' not supported for vendor {vendor.value}"
+            )
+
+        return models[vendor]
 
     def get_vendor_model_id(self, model_name: str, vendor: Vendor) -> str:
         """
@@ -293,18 +324,25 @@ class SupportedModels:
         )
 
     def resolve_model_id(self, model_id: str, vendor: Vendor) -> str:
-        """
-        Resolve a model identifier to its vendor-specific form.
+        """Resolve ``model_id`` to the vendor-specific identifier for ``vendor``.
 
-        This method handles both canonical names and vendor-specific IDs.
+        ``model_id`` may already be a vendor specific ID or a canonical name.
 
         Args:
-            model_id (str): The model identifier to resolve
-            vendor (Vendor): The target vendor
+            model_id: Identifier to resolve. Can be canonical or vendor specific.
+            vendor: The vendor for which the ID should be resolved.
 
         Returns:
-            str: The vendor-specific model identifier
+            The vendor-specific identifier.
         """
+
+        # If ``model_id`` already matches a known vendor specific ID for the
+        # requested vendor, return it unchanged.
+        for mapping in self._model_mappings.values():
+            if mapping.vendor_ids.get(vendor) == model_id:
+                return model_id
+
+        # Otherwise treat ``model_id`` as a canonical name and resolve normally.
         return self.get_vendor_model_id(model_id, vendor)
 
     def resolve_model_name_and_vendor(

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -155,3 +155,23 @@ class TestModelSelectionScenarios:
             "claude-3-haiku-20240307", Vendor.ANTHROPIC
         )
         assert anthropic_id == "claude-3-haiku-20240307"
+
+    def test_resolve_model_id_with_vendor_specific_id(self):
+        """Vendor specific IDs should resolve to themselves."""
+        models = SupportedModels()
+
+        aws_specific = "anthropic.claude-3-haiku-20240307-v1:0"
+        resolved = models.resolve_model_id(aws_specific, Vendor.AWS)
+        assert resolved == aws_specific
+
+    def test_get_model_by_specific_vendor(self):
+        """Ensure vendor-specific model instances can be retrieved."""
+        models = SupportedModels()
+
+        aws_model = models.get_model("claude-3-7-sonnet-20250219", Vendor.AWS)
+        anthropic_model = models.get_model(
+            "claude-3-7-sonnet-20250219", Vendor.ANTHROPIC
+        )
+
+        assert aws_model.vendor == Vendor.AWS
+        assert anthropic_model.vendor == Vendor.ANTHROPIC


### PR DESCRIPTION
## Summary
- refine `resolve_model_id` to recognise vendor-specific IDs
- add test covering vendor-specific ID resolution
- introduce `docs/slides.md` with Reveal.js style slides

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842ab33a3408328b34b8867a30fe08a